### PR TITLE
Fix a crash caused by calling BaseFileName on virtual pages

### DIFF
--- a/layouts/partials/_mdinclude.html
+++ b/layouts/partials/_mdinclude.html
@@ -3,7 +3,7 @@
 
 {{- define "siteBlock" -}}
 	{{ $path := printf "_layout/%s/_index.%s.md" .name .page.Lang}}	
-	{{ range where .page.Site.Pages "File.BaseFileName" $path }}
+	{{ range where .page.Site.RegularPages "File.BaseFileName" $path }}
 		{{ .Content }} 
 	{{else}}
 		{{ $path = printf "_layout/%s/_index.md" .name }}	


### PR DESCRIPTION
Hugo starting with version 0.123 crashes when docport tries to reference BaseFileName on a virtual page. It used to just warn about it.

https://discourse.gohugo.io/t/upgrade-from-0-122-to-0-123/48576

The fix is to range over "Regular" pages instead of all pages.